### PR TITLE
Add addLoadMiddlewareFirst

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,10 +9,15 @@
         ];
 
         dust.addLoadMiddleware = addLoadMiddleware;
+        dust.addLoadMiddlewareFirst = addLoadMiddlewareFirst;
         dust.clearMiddleware = clearMiddleware;
 
         function addLoadMiddleware(middleware) {
             middlewares.push(middleware);
+        }
+
+        function addLoadMiddlewareFirst(middleware) {
+            middlewares.unshift(middleware);
         }
 
         function clearMiddleware() {

--- a/test/test-dustjacket.js
+++ b/test/test-dustjacket.js
@@ -203,3 +203,28 @@ test('legacy onLoad is called', function (t) {
         t.end();
     });
 });
+
+test('adding middleware first go first', function (t) {
+    var dust = freshy('dustjs-linkedin');
+
+    dustjacket.registerWith(dust);
+
+    t.plan(2);
+
+    var called = [];
+    dust.addLoadMiddleware(function (name, context, cb) {
+        called.push('after');
+        cb();
+    });
+
+    dust.addLoadMiddlewareFirst(function (name, context, cb) {
+        called.push('first');
+        cb();
+    });
+
+    dust.render('test', {}, function (err, out) {
+        t.equal(called[0], 'first', 'first was called first');
+        t.equal(called[1], 'after', 'after was called after');
+        t.end();
+    });
+});


### PR DESCRIPTION
This is one possible way of letting name-mapping middleware load before the default caching.

The other alternative I see is letting there be a separate post-load chain.

(this is starting to sound like an addressable pipeline rather than middleware)

Thoughts?
